### PR TITLE
Отсутствует `@nuxt/eslint-config` в peer-зависимостях

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "prettier-plugin-packagejson": "2.4.3"
   },
   "peerDependencies": {
+    "@nuxt/eslint-config": "*",
     "eslint": "*",
     "eslint-config-prettier": "*",
     "eslint-plugin-jsdoc": "*",


### PR DESCRIPTION
- Fix #16